### PR TITLE
added option to set audio output to both hdmi and local

### DIFF
--- a/src/View/Settings.php
+++ b/src/View/Settings.php
@@ -137,6 +137,7 @@ class Settings extends View
                 <select class="selectpicker" name="setting[audioout]">
                     <option value="hdmi">HDMI</option>
                     <option value="local">Local</option>
+                    <option value="both">Both</option>
                 </select>
             </div>
 


### PR DESCRIPTION
I have been using the previous version of your software for more than a year now and I am very glad to see,that you are working on a new version.
I already had a local modification of the startup shell script to send audio to both Raspberry Pi audio outputs and now I would like to contribute to this new project with this commit.