### PR TITLE
added subtitles folder to settings

### DIFF
--- a/omx-start.sh
+++ b/omx-start.sh
@@ -11,7 +11,15 @@ then
     rm $1
 fi
 mkfifo $1
-omxplayer -b "$2" -o $4 --vol $5 < $1 &
+
+filename=$(basename $2)
+subtitle_path="$6/${filename%.*}.srt"
+if [ -e "$subtitle_path" ]; then
+  omxplayer -b "$2" -o $4 --subtitles "$subtitle_path" < $1 &
+  else
+  omxplayer -b "$2" -o $4 < $1 &
+fi
+
 echo -n "." > $1 &
 
 # fix for double play speed at start

--- a/omx-start.sh
+++ b/omx-start.sh
@@ -12,14 +12,16 @@ then
 fi
 mkfifo $1
 
-filename=$(basename $2)
-subtitle_path="$6/${filename%.*}.srt"
+# check if subtitle file exists in subtitle folder
+basename=$(basename $2)
+subtitle_path="$6/${basename%.*}.srt"
 if [ -e "$subtitle_path" ]; then
-  omxplayer -b "$2" -o $4 --subtitles "$subtitle_path" < $1 &
+  subtitle_argument="--subtitles $subtitle_path"
   else
-  omxplayer -b "$2" -o $4 < $1 &
+  subtitle_argument=""
 fi
 
+omxplayer -b "$2" -o $4 --vol $5 $subtitle_argument < $1 &
 echo -n "." > $1 &
 
 # fix for double play speed at start

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -74,7 +74,8 @@ class Translation
                 "settings.resetflags.desc" => "Delete all seen flags from all videos with just one click",
                 "settings.hidefolder.title" => "Hide folder names in playlist",
                 "settings.hidefolder.desc" => "Enable a more compact view for the playlist by hiding the folder names",
-
+                "settings.subtitlesfolder.title" => "Subtitles folder",
+                "settings.subtitlesfolder.desc" => "If you would like to keep your subtitle files in a separate place from your media files, you can provide the folder here.",
             ],
             "de" => [
                 "shortcut-q" => "Stoppe\nPlayer",
@@ -134,6 +135,8 @@ class Translation
                 "settings.resetflags.desc" => "Lösche alle gesehen Flags mit einem Klick",
                 "settings.hidefolder.title" => "Verstecke Ordnername in Wiedergabeliste",
                 "settings.hidefolder.desc" => "Aktiviere eine kompaktere Ansicht mit dieser Option",
+                "settings.subtitlesfolder.title" => "Untertitel Ordner",
+                "settings.subtitlesfolder.desc" => "Wenn Sie Ihre Untertitel-Dateien an einem anderen Ort aus Ihren Mediendateien speichern möchten, können Sie den Ordner hier angeben.",
             ]
         ];
 }

--- a/src/View/Index.php
+++ b/src/View/Index.php
@@ -62,7 +62,9 @@ class Index extends View
                 isset($settings["speedfix"]) && $settings["speedfix"] ? "1"
                     : "0",
                 isset($settings["audioout"]) ? $settings["audioout"] : "hdmi",
-                isset($settings["initvol"]) ? $settings["initvol"] * 100 : "0"
+                isset($settings["initvol"]) ? $settings["initvol"] * 100 : "0",
+                isset($settings["subtitles_folder"]) ? "'" .
+                    $settings["subtitles_folder"] . "'" : false,
             ];
             $startCmd = escapeshellarg($path) . " " . implode(" ", $params);
             switch (post("shortcut")) {

--- a/src/View/Settings.php
+++ b/src/View/Settings.php
@@ -166,6 +166,17 @@ class Settings extends View
                     <option value="de">Deutsch</option>
                 </select>
             </div>
+
+            <div class="title spacer">
+                <strong><?= t("settings.subtitlesfolder.title") ?></strong>
+                <small><?= t("settings.subtitlesfolder.desc") ?></small>
+            </div>
+            <div class="spacer">
+                <input type="text"
+                       placeholder="<?= t("settings.subtitlesfolder.title") ?>"
+                       name="setting[subtitles_folder]"
+                       class="form-control">
+            </div>
             <input type="submit" value="<?= t("save") ?>" name="save"
                    class="btn btn-default btn-info">
         </form>


### PR DESCRIPTION
I am not sure if this use case is common, but this new setting enables the users to specifiy a separate folder which contains `.srt` subtitle files. If a subtitle filename matches the played video, then it is used as a subtitle.